### PR TITLE
Create implementation skeleton

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get -y install plantuml
-        python -m pip install -r docs/requirements.txt
+        python -m pip install Sphinx sphinx_rtd_theme sphinxcontrib-plantuml .
 
     - name: Build site
       working-directory: docs

--- a/README.md
+++ b/README.md
@@ -1,73 +1,37 @@
-# Group Project Management System
+# Acanban
 
-# Deployment
+Acanban is an academic [Kanban board].  It aims to provide
+a collaboration platform for students and mentors, with first-class support
+for academic evaluation.
 
-## Requirements
+## Prerequisites
 
-### Python packages
+Acanban runs on Python 3.7+ and requires [RethinkDB] and [IPFS] 0.7 or above.
 
-These packages should be installed in a Python virtual environment.
+## Setup
 
-- Quart-Trio
-- HyperCorn
+The development version of Acanban can be installed from this git repository:
 
-### Server requirements
-
-- NGINX
-- IPFS
-- RethinkDB
-
-## Configuration
-
-### Configure NGINX file
-
-Add following file as `/etc/nginx/sites-available/gpms`
-
-```nginx
-server {
-	listen 80;
-	server_name <IP address or domain name>;
-	location / {
-		include proxy_params;
-		proxy_pass http://unix:/var/www/gpms/gpms.sock;
-	}
-}
+```bash
+python -m pip install git+https://github.com/Huy-Ngo/acanban
 ```
 
-Make a symlink to `/etc/nginx/sites-enabled/`
-
-### Configure files for RethinkDB
-
-We use init.d to run RethinkDB on startup.
-Configuration file should be put at `/etc/rethinkdb/instances.d/`.
-A sample file can be found on [RethinkDB's GitHub repo][1].
-
-More configuration for security can be found on [RethinkDB's Doc][2].
-However, at this point the security decision haven't been made
-
-### Configure systemd service
-
-We use systemd to run GPMS.
+Acanban can then be evoked via `python -m acanban`.  In production,
+it is typical to run it as a systemd service, configured like followed.
 
 ```ini
 [Unit]
-Description=Instance to serve GPMS
+Description=The Acanban Server
 After=network.target
 
 [Service]
-User=username
-WorkingDirectory=/home/username/gpms
-ExecStart=/home/username/gpms/venv/bin/python -m hypercorn -w 5 -k trio gpms:app
+ExecStart=/path/to/venv/bin/python -m acanban
+Restart=on-failure
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target
 ```
 
-Start the service:
-
-```bash
-systemctl start gpms.service
-```
-
-[1]: https://github.com/rethinkdb/rethinkdb/blob/next/packaging/assets/config/default.conf.sample
-[2]: https://rethinkdb.com/docs/security/
+[Kanban board]: https://en.wikipedia.org/wiki/Kanban_board
+[RethinkDB]: https://rethinkdb.com/docs/install/
+[IPFS]: https://ipfs.io

--- a/acanban/__init__.py
+++ b/acanban/__init__.py
@@ -1,0 +1,33 @@
+# Initialization code
+# Copyright (C) 2020  Nguyễn Gia Phong
+#
+# This file is part of Acanban.
+#
+# Acanban is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Acanban is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Acanban.  If not, see <https://www.gnu.org/licenses/>.
+
+from quart_trio import QuartTrio
+
+from .static import index_html
+
+__all__ = ['app']
+__doc__ = 'Academic Kanban'
+__version__ = '0.0.1'
+
+app = QuartTrio(__name__)
+
+
+@app.route('/')
+async def index() -> str:
+    """Return the index page."""
+    return index_html

--- a/acanban/__main__.py
+++ b/acanban/__main__.py
@@ -1,0 +1,29 @@
+# Server console script
+# Copyright (C) 2020  Nguyễn Gia Phong
+#
+# This file is part of Acanban.
+#
+# Acanban is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Acanban is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Acanban.  If not, see <https://www.gnu.org/licenses/>.
+
+from hypercorn.config import Config
+from hypercorn.trio import serve
+from trio import run
+
+from . import app
+
+
+if __name__ == '__main__':
+    config = Config()
+    config.bind = ['localhost:42069']
+    run(serve, app, config)

--- a/acanban/static/__init__.py
+++ b/acanban/static/__init__.py
@@ -1,0 +1,29 @@
+# Static data
+# Copyright (C) 2020  Nguyễn Gia Phong
+#
+# This file is part of Acanban.
+#
+# Acanban is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Acanban is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Acanban.  If not, see <https://www.gnu.org/licenses/>.
+
+from importlib.resources import open_text
+
+__all__ = ['index_html']
+
+
+def read(resource: str) -> str:
+    """Return the content of the given static resource."""
+    with open_text('acanban.static', resource) as f: return f.read()
+
+
+index_html = read('index.html')

--- a/acanban/static/index.html
+++ b/acanban/static/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<meta charset=utf-8>
+<title>Acanban</title>
+<body>
+<p>Welcome to Acanban!</p>
+</body>
+</html>

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,0 @@
-Sphinx >= 3
-sphinx_rtd_theme
-sphinxcontrib-plantuml

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,11 +4,13 @@
 # For a full list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+from acanban import __version__
+
 # Project information
-project = 'gpms'
-copyright = '2020'
-author = ''
-release = '0.0.0'
+project = 'Acanban'
+copyright = '2020  Ngô Ngọc Đức Huy et al.'
+author = 'Ngô Ngọc Đức Huy et al.'
+release = __version__
 
 # Add any Sphinx extension module names here, as strings.
 # They can be extensions coming with Sphinx (named 'sphinx.ext.*')

--- a/docs/source/solution/distribution.rst
+++ b/docs/source/solution/distribution.rst
@@ -12,19 +12,19 @@ Deployment Model
 
    node Server {
       database "RethinkDB" as db
-      artifact "/etc/systemd/system/gpms.service" as systemd_conf
-      component GPMS as gpms
-      component hypercorn
+      artifact "acanban.service" as systemd_conf
+      component Acanban
+      component Hypercorn
       node systemd <<daemon>>
       component IPFS
    }
 
-   Browser --- hypercorn: HTTPS
-   hypercorn - systemd: run instance
+   Browser --- Hypercorn: HTTPS
+   Hypercorn - systemd: run instance
    systemd <- systemd_conf: configure
-   hypercorn -- gpms
-   gpms - IPFS
-   gpms - db
+   Hypercorn -- Acanban
+   Acanban - IPFS
+   Acanban - db
 
 Alternative deployment model with load-balancing and a separate data server:
 
@@ -36,13 +36,13 @@ Alternative deployment model with load-balancing and a separate data server:
 
    node "Load Balancing Server" as balancer {
       component NGINX as nginx <<load balancer>>
-      artifact "/etc/nginx/sites-available/gpms" as nginx_conf
+      artifact "/etc/nginx/sites-available/acanban" as nginx_conf
    }
 
    node Server {
-      artifact "/etc/systemd/system/gpms.service" as systemd_conf
-      component GPMS as gpms
-      component hypercorn
+      artifact "acanban.service" as systemd_conf
+      component Acanban
+      component Hypercorn
       node systemd <<daemon>>
    }
 
@@ -56,7 +56,7 @@ Alternative deployment model with load-balancing and a separate data server:
    nginx <. nginx_conf: configure
    nginx "1" --- "1..*" Server
 
-   hypercorn - systemd: run instance
+   Hypercorn - systemd: run instance
    systemd <. systemd_conf: configure
-   hypercorn -- gpms
-   gpms "1..*" -- "1" db_server
+   Hypercorn -- Acanban
+   Acanban "1..*" -- "1" db_server

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ['flit_core >=2,<4']
+build-backend = 'flit_core.buildapi'
+
+[tool.flit.metadata]
+module = 'acanban'
+author = 'Ngô Ngọc Đức Huy'
+author-email = 'duchuy29092000@gmail.com'
+home-page = 'https://Huy-Ngo.github.io/acanban'
+requires = ['hypercorn', 'quart-trio']
+description-file = 'README.md'
+classifiers = [
+    'Development Status :: 1 - Planning',
+    'Environment :: Web Environment',
+    'Framework :: Trio',
+    'Intended Audience :: Education',
+    'Intended Audience :: End Users/Desktop',
+    'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
+    'Natural Language :: English',
+    'Natural Language :: Vietnamese',
+    'Operating System :: OS Independent',
+    'Programming Language :: Python :: 3 :: Only',
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
+    'Topic :: Education',
+    'Typing :: Typed']
+requires-python = '>=3.7'
+keywords = 'academic,kanban'
+license = 'AGPLv3+'


### PR DESCRIPTION
This does a few things:

* Rename to Acanban (fix GH-7)
* Remove setup instructions for 3rd-party software
* Set up the base for implementation
* Set up packaging (mainly for later use of tox, but we may want to publish to a package index too)

I'm sorry for shoving so many stuff into one PR, but they quite intertwine with each other.