### PR TITLE
Wrap RethinkDB objects in a mixin class

### DIFF
--- a/src/acanban/db.py
+++ b/src/acanban/db.py
@@ -1,0 +1,73 @@
+# Authentication handler
+# Copyright (C) 2020  Nguyễn Gia Phong
+#
+# This file is part of Acanban.
+#
+# Acanban is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Acanban is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Acanban.  If not, see <https://www.gnu.org/licenses/>.
+
+from typing import Any, Awaitable, Tuple
+
+from quart import current_app
+from rethinkdb import r
+
+__all__ = ['RethinkObject']
+
+
+async def get(table: str, key: str, field: str) -> str:
+    """Return DB[table][key][field]."""
+    async with current_app.db_pool.connection() as conn:
+        return await r.table(table).get(key)[field].run(conn)
+
+
+class RethinkObject:
+    """RethinkDB object wrapper mixin.
+
+    Exceptions raised by RethinkDB are expected to be handled by caller.
+    """
+
+    slots: Tuple[str, ...]
+    table: str
+    key: str
+
+    def __getattr__(self, name: str) -> Awaitable[str]:
+        if name not in self.slots:
+            cls = self.__class__.__name__
+            raise AttributeError(f'{cls!r} object has no attribute {name!r}')
+        return get(self.table, self.key, name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name in self.slots:
+            cls = self.__class__.__name__
+            raise AttributeError(
+                f'{cls}.update must be used for dynamic attribute {name!r}')
+        super().__setattr__(name, value)
+
+    async def update(self, **kwargs: str) -> None:
+        """Update the RethinkDB object from given keys and values.
+
+        This is defined instead of `__setattr__` because
+        it is impossible to await an assignment statement.
+
+        Raise
+        -----
+        ValueError
+            If one or more field name in kwargs undeclared in slots.
+        """
+        invalid = ', '.join(repr(field) for field in kwargs
+                            if field not in self.slots)
+        if invalid:
+            cls = self.__class__.__name__
+            raise ValueError(f'cannot dynamically set {invalid} in {cls!r}')
+        async with current_app.db_pool.connection() as conn:
+            await r.table(self.table).get(self.key).update(kwargs).run(conn)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -17,14 +17,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Acanban.  If not, see <https://www.gnu.org/licenses/>.
 
-from crypt import crypt
-from hmac import compare_digest
-
 from pytest import mark
 from quart.testing import QuartClient
-
-from acanban import Acanban
-from acanban.auth import User
 
 
 @mark.parametrize(('username', 'role', 'code'),
@@ -50,14 +44,3 @@ async def test_login(username: str, password: str, code: int,
         '/login', form=dict(username=username, password=password))
     # Successful login redirects.
     assert response.status_code == code
-
-
-async def test_user(app: Acanban) -> None:
-    """Test if properties for User object is correct."""
-    async with app.app_context():
-        user = User('silasl')
-        digest = await user.password
-        assert compare_digest(digest, crypt('lsalis', digest))
-        assert await user.email == 'silasl@example.edu'
-        assert await user.name == 'Silas Lehtonen'
-        assert await user.role == 'assistant'

--- a/tests/test_db_wrapper.py
+++ b/tests/test_db_wrapper.py
@@ -1,0 +1,52 @@
+# Test RethinkDB wrapper
+# Copyright (C) 2020  Ngô Ngọc Đức Huy
+# Copyright (C) 2020  Nguyễn Gia Phong
+#
+# This file is part of Acanban.
+#
+# Acanban is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Acanban is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Acanban.  If not, see <https://www.gnu.org/licenses/>.
+
+from crypt import crypt
+from hmac import compare_digest
+
+from pytest import raises
+
+from acanban import Acanban
+from acanban.auth import User
+
+
+async def test_object_get(app: Acanban) -> None:
+    """Test object get attributes."""
+    async with app.app_context():
+        user = User('silasl')
+        digest = await user.password
+        assert compare_digest(digest, crypt('lsalis', digest))
+        assert await user.email == 'silasl@example.edu'
+        assert await user.name == 'Silas Lehtonen'
+        assert await user.role == 'assistant'
+        with raises(AttributeError): await user.kink
+
+
+async def test_object_set(app: Acanban) -> None:
+    """Test object set attributes."""
+    async with app.app_context():
+        user, monty = User('silasl'), 'Monty Python'
+        name = await user.name
+        with raises(AttributeError): user.name = monty
+
+        await user.update(name=monty)
+        assert await user.name == monty
+        await user.update(name=name)
+
+        with raises(ValueError): await user.update(kink='DBMS')


### PR DESCRIPTION
This reduce the fraction when declare new wrapper classes:
It is no longer needed to define (or test) each descriptor individually.

The old test for User is now used as the generic test for the wrapper.

<sup>This PR also serves my thirst for meta programming but let's ignore that.</sup>