### PR TITLE
Rename the use case for Task

### DIFF
--- a/docs/source/req/use-case.rst
+++ b/docs/source/req/use-case.rst
@@ -230,7 +230,7 @@ None.
 
 
 Assign Tasks
-----------
+------------
 
 Brief Description
 ^^^^^^^^^^^^^^^^^

--- a/docs/source/req/use-case.rst
+++ b/docs/source/req/use-case.rst
@@ -12,7 +12,7 @@ Use-Case Model
    usecase "Create project" as CreateP
    usecase "Join project" as JoinP
    usecase "Create tasks" as CreateT
-   usecase "Join tasks" as JoinT
+   usecase "Assign tasks" as AssignT
    usecase "Complete tasks" as Complete
    usecase "View results" as View
    usecase Evaluate
@@ -44,7 +44,7 @@ Use-Case Model
    Student --> CreateP
    Student --> CreateT
    Student --> JoinP
-   Student --> JoinT
+   Student --> AssignT
    Student --> Complete
    Student --> Thread
    Student --> Comment
@@ -229,13 +229,13 @@ Extension Points
 None.
 
 
-Join Tasks
+Assign Tasks
 ----------
 
 Brief Description
 ^^^^^^^^^^^^^^^^^
 
-This use case allows Student to join task(s) in the project.
+This use case allows a participant to assign a task to someone.
 
 Flow of Events
 ^^^^^^^^^^^^^^
@@ -243,8 +243,10 @@ Flow of Events
 Basic Flow
 """"""""""
 
-1. Student requests to join task(s) in the task list.
-2. System receives the request and allows Student to join the task(s).
+1. Student selects the task and and choose "Assign".
+2. Student choose the participant to assign to.
+3. System receives the request and register the participant
+   as assigned for that task.
 
 Alternative Flow
 """"""""""""""""


### PR DESCRIPTION
In this PR, I rename the use case "Join Task" to "Assign Task". Description is edited accordingly.

As I write this, I realize we didn't have use case for:

- Removing a participant (let's say they added that person by mistake)
- Adding a participant (well this should be the default way to do it)
- Unassign/Reassign the task (like GH)

These can arise in another issue(s) but I'm just noting here.

Resolve #53 