### PR TITLE
Read RethinkDB configuration from files

### DIFF
--- a/.builds/test.yml
+++ b/.builds/test.yml
@@ -2,7 +2,6 @@ image: debian/buster
 packages:
   - python3-pip
   - rethinkdb
-  - tox
 repositories:
   rethinkdb: https://download.rethinkdb.com/repository/debian-buster buster main 539A3A8C6692E6E3F69B3FE81D85E93F801BB43F
 sources:
@@ -11,7 +10,8 @@ tasks:
   - rethinkdb: |
       sudo cp /etc/rethinkdb/default.conf.sample /etc/rethinkdb/instances.d/instance1.conf
       sudo /etc/init.d/rethinkdb start
-      tar -czvf rethinkdump.tar.gz -C acanban/tests/assets rethinkdump
-      python3 -m pip install rethinkdb
-      python3 -m rethinkdb restore rethinkdump.tar.gz
-  - test: tox -c acanban -e py
+  - test: |
+      python3 -m pip install tox
+      python3 -m tox -c acanban -e py
+environment:
+  PIP_PROGRESS_BAR: 'off'

--- a/README.md
+++ b/README.md
@@ -32,6 +32,31 @@ Restart=on-failure
 WantedBy=default.target
 ```
 
+## Configuration
+
+Acanban's configuration files are looked for
+in [user and site config dir][appdirs] (in that order),
+with `acanban` namespace.
+
+### Hypercorn
+
+[Hypercorn configuration][hypercorn.toml] is loaded from `hypercorn.toml`.
+Acanban does not override any of the server's defaults.
+
+### RethinkDB
+
+Values defined in `rethinkdb.toml` will be passed to the RethinkDB client.
+Below are some of the fields that commonly need to be configured
+and their default values:
+
+```toml
+host = 'localhost'
+port = 28015
+user = 'admin'
+timeout = 20
+db = 'test'
+```
+
 ## Hacking
 
 First clone the repository and install Acanban as editable:
@@ -54,3 +79,5 @@ tox
 [Kanban board]: https://en.wikipedia.org/wiki/Kanban_board
 [RethinkDB]: https://rethinkdb.com/docs/install/
 [IPFS]: https://ipfs.io
+[appdirs]: https://pypi.org/project/appdirs/
+[hypercorn.toml]: https://pgjones.gitlab.io/hypercorn/how_to_guides/configuring.html

--- a/src/acanban/__init__.py
+++ b/src/acanban/__init__.py
@@ -29,6 +29,7 @@ from rethinkdb.trio_net.net_trio import TrioConnectionPool
 from trio import open_nursery
 
 from .auth import Authenticator, blueprint as auth
+from .config import RETHINKDB_DEFAULT
 
 __all__ = ['app']
 __doc__ = 'Academic Kanban'
@@ -40,6 +41,7 @@ class Acanban(QuartTrio):
 
     auth_manager: Authenticator
     db_pool: TrioConnectionPool
+    rethinkdb_config = RETHINKDB_DEFAULT
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -67,7 +69,8 @@ app.register_blueprint(auth)
 async def create_db_pool() -> None:
     """Create RethinkDB connection pool."""
     r.set_loop_type('trio')
-    app.db_pool = r.ConnectionPool(db='test', nursery=app.nursery)
+    app.db_pool = r.ConnectionPool(
+        nursery=app.nursery, **app.rethinkdb_config)
 
 
 @app.after_serving

--- a/src/acanban/__main__.py
+++ b/src/acanban/__main__.py
@@ -17,13 +17,12 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Acanban.  If not, see <https://www.gnu.org/licenses/>.
 
-from appdirs import site_config_dir, user_config_dir
 from hypercorn.trio import serve
 from trio import run
 
 from . import app
-from .config import hypercorn_config
+from .config import hypercorn_config, rethinkdb_config
 
 if __name__ == '__main__':
-    config = hypercorn_config(user_config_dir(), site_config_dir())
-    run(serve, app, config)
+    app.rethinkdb_config = rethinkdb_config()
+    run(serve, app, hypercorn_config())

--- a/src/acanban/config.py
+++ b/src/acanban/config.py
@@ -17,13 +17,29 @@
 # along with Acanban.  If not, see <https://www.gnu.org/licenses/>.
 
 from os.path import isfile, join
+from typing import Any, MutableMapping, Sequence
 
-from hypercorn.config import Config
+import toml
+from appdirs import site_config_dir, user_config_dir
+from hypercorn.config import Config as HyperConf
+
+TomMapping = MutableMapping[str, Any]
+
+CONFIG_DIRS = user_config_dir('acanban'), site_config_dir('acanban')
+RETHINKDB_DEFAULT: TomMapping = {'db': 'test'}
 
 
-def hypercorn_config(*directories: str) -> Config:
+def hypercorn_config(dirs: Sequence[str] = CONFIG_DIRS) -> HyperConf:
     """Return Hypercorn configuration first found in given directories."""
-    for directory in directories:
+    for directory in dirs:
         file = join(directory, 'hypercorn.toml')
-        if isfile(file): return Config.from_toml(file)
-    return Config()
+        if isfile(file): return HyperConf.from_toml(file)
+    return HyperConf()
+
+
+def rethinkdb_config(dirs: Sequence[str] = CONFIG_DIRS) -> TomMapping:
+    """Return Hypercorn configuration first found in given directories."""
+    for directory in dirs:
+        file = join(directory, 'rethinkdb.toml')
+        if isfile(file): return toml.load(file)
+    return RETHINKDB_DEFAULT

--- a/tests/assets/rethinkdb.toml
+++ b/tests/assets/rethinkdb.toml
@@ -1,0 +1,1 @@
+db = 'foobar'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,21 +22,33 @@ from typing import Any, Mapping, Sequence
 import toml
 from pytest import mark, param
 
-from acanban.config import hypercorn_config
+from acanban.config import (RETHINKDB_DEFAULT,
+                            hypercorn_config, rethinkdb_config)
 
 CONFIG_DIR = abspath(join(dirname(__file__), 'assets'))
 EMPTY_DIR = 'this directory does not exist'
 
 HYPERCORN_MOCK = toml.load(join(CONFIG_DIR, 'hypercorn.toml'))
 HYPERCORN_DEFAULT = {'bind': ['127.0.0.1:8000']}
+RETHINKDB_MOCK = toml.load(join(CONFIG_DIR, 'rethinkdb.toml'))
 
 
 @mark.parametrize(('dirs', 'mapping'), (
     param([CONFIG_DIR], HYPERCORN_MOCK, id='load'),
-    param([EMPTY_DIR, CONFIG_DIR], HYPERCORN_MOCK, id='load'),
+    param([EMPTY_DIR, CONFIG_DIR], HYPERCORN_MOCK, id='find'),
     param([EMPTY_DIR], HYPERCORN_DEFAULT, id='fallback')))
 def test_hypercorn_config(dirs: Sequence[str],
                           mapping: Mapping[str, Any]) -> None:
     """Test loading Hypercorn configuration."""
-    config = hypercorn_config(*dirs)
+    config = hypercorn_config(dirs)
     for key, value in mapping.items(): assert getattr(config, key) == value
+
+
+@mark.parametrize(('dirs', 'mapping'), (
+    param([CONFIG_DIR], RETHINKDB_MOCK, id='load'),
+    param([EMPTY_DIR, CONFIG_DIR], RETHINKDB_MOCK, id='find'),
+    param([EMPTY_DIR], RETHINKDB_DEFAULT, id='fallback')))
+def test_rethinkdb_config(dirs: Sequence[str],
+                          mapping: Mapping[str, Any]) -> None:
+    """Test loading RethinkDB configuration."""
+    assert rethinkdb_config(dirs) == mapping

--- a/tox.ini
+++ b/tox.ini
@@ -7,10 +7,17 @@ minversion = 3.3
 isolated_build = true
 
 [testenv]
+allowlist_externals =
+    rm
+    tar
 deps =
     pytest-cov
     pytest-trio
-commands = pytest {posargs}
+commands =
+    tar -czvf rethinkdump.tar.gz -C tests/assets rethinkdump
+    rethinkdb-restore rethinkdump.tar.gz
+    rm rethinkdump.tar.gz
+    pytest {posargs}
 
 [testenv:type]
 deps =


### PR DESCRIPTION
This only happens in `__main__.py`, i.e. when one calls `python -m acanban`.  During automated testing, the configuration files are not loaded to maintain isolation.

In addition, loading RethinkDB dump is now done by Tox for the convenience of local testing.

This resolves GH-50.