### PR TITLE
Implement user profile endpoint

### DIFF
--- a/src/acanban/__init__.py
+++ b/src/acanban/__init__.py
@@ -30,6 +30,7 @@ from trio import open_nursery
 
 from .auth import Authenticator, blueprint as auth
 from .config import RETHINKDB_DEFAULT
+from .user import blueprint as user
 
 __all__ = ['app']
 __doc__ = 'Academic Kanban'
@@ -63,6 +64,7 @@ class Acanban(QuartTrio):
 
 app = Acanban(__name__)
 app.register_blueprint(auth)
+app.register_blueprint(user)
 
 
 @app.before_serving

--- a/src/acanban/static/style.css
+++ b/src/acanban/static/style.css
@@ -66,7 +66,7 @@ button, input, select, textarea {
     font-family: inherit;
     font-size: 100%;
 }
-input[type=text], input[type=password], input[type=email], input[type=submit],
+button, input[type=text], input[type=password], input[type=email], input[type=submit],
 select {
     background-color: var(--color-bg);
     border: 0.1rem solid var(--color-fg);
@@ -84,12 +84,12 @@ input:focus, select:focus {
     border-color: var(--color-primary-dark);
     box-shadow: 0 0 0.5rem var(--color-primary-bright);
 }
-input[type=submit] {
+button, input[type=submit] {
     background-color: var(--color-primary-dark);
     color: var(--color-bg);
     cursor: pointer;
 }
-input[type=submit]:hover { background-color: var(--color-primary-medium) }
+button, input[type=submit]:hover { background-color: var(--color-primary-medium) }
 
 /* messages */
 .error, .info, .success, .warning {

--- a/src/acanban/templates/user_profile.html
+++ b/src/acanban/templates/user_profile.html
@@ -1,0 +1,38 @@
+<!-- User profile page
+Copyright (C) 2020  Ngô Ngọc Đức Huy
+
+This file is part of Acanban.
+
+Acanban is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Acanban is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with Acanban.  If not, see <https://www.gnu.org/licenses/>. -->
+
+{% extends 'base.html' %}
+
+{% block title %}
+{{name}}'s profile
+{% endblock %}
+
+{% block content %}
+
+<h1>{{ name }}</h1>
+<div>{{ role }}</div>
+<div>u/{{ username }}</div>
+<div>{{ email }}</div>
+
+{% if username == current_user.key %}
+<a href="{{url_for('user.edit_user_profile', username=username) }}">
+  <button>Edit profile</button>
+</a>
+{% endif %}
+
+{% endblock%}

--- a/src/acanban/templates/user_profile_edit.html
+++ b/src/acanban/templates/user_profile_edit.html
@@ -1,0 +1,39 @@
+<!-- User profile page
+Copyright (C) 2020  Ngô Ngọc Đức Huy
+
+This file is part of Acanban.
+
+Acanban is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Acanban is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with Acanban.  If not, see <https://www.gnu.org/licenses/>. -->
+
+{% extends 'base.html' %}
+
+{% block title %}
+Edit profile
+{% endblock %}
+
+{% block content %}
+
+<h1>Edit profile</h1>
+
+<form action="edit" method="POST">
+  <label for="name">Full name</label>
+  <input type="text" name="name" id="name"
+    value="{{ name }}" required/>
+  <label for="email">Email</label>
+  <input type="email" name="email" id="email"
+    value="{{ email }}" required/>
+  <input type="submit" id="submit" value="Save">
+</form>
+
+{% endblock%}

--- a/src/acanban/user.py
+++ b/src/acanban/user.py
@@ -1,0 +1,67 @@
+# User profile endpoints
+# Copyright (C) 2020  Ngô Ngọc Đức Huy
+#
+# This file is part of Acanban.
+#
+# Acanban is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Acanban is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Acanban.  If not, see <https://www.gnu.org/licenses/>.
+
+from http import HTTPStatus
+
+from quart import (Blueprint, ResponseReturnValue, abort,
+                   redirect, render_template, request, url_for)
+from quart_auth import current_user
+from rethinkdb.errors import ReqlNonExistenceError
+from werkzeug.exceptions import BadRequestKeyError
+
+from .auth import User
+
+__all__ = ['blueprint']
+
+blueprint = Blueprint('user', __name__, url_prefix='/u')
+
+
+@blueprint.route('/<username>', methods=['GET'])
+async def view_user_profile(username: str) -> ResponseReturnValue:
+    """Handle the user profile page."""
+    user = User(username)
+    try:
+        return await render_template('user_profile.html',
+                                     username=user.key,
+                                     email=await user.email,
+                                     role=await user.role,
+                                     name=await user.name)
+    except ReqlNonExistenceError:
+        abort(HTTPStatus.NOT_FOUND)
+
+
+@blueprint.route('/<username>/edit', methods=['GET', 'POST'])
+async def edit_user_profile(username: str) -> ResponseReturnValue:
+    """Handle the profile edit page."""
+    user = User(username)
+    if user.key != current_user.key:
+        abort(HTTPStatus.FORBIDDEN)
+    if request.method == 'GET':
+        return await render_template('user_profile_edit.html',
+                                     email=await user.email,
+                                     name=await user.name)
+    info = await request.form
+    try:
+        data = {'name': info['name'],
+                'email': info['email']}
+    except BadRequestKeyError:
+        abort(HTTPStatus.BAD_REQUEST)
+    if data['name'] == '' or data['email'] == '':
+        abort(HTTPStatus.BAD_REQUEST)
+    await user.update(**data)
+    return redirect(url_for('user.view_user_profile', username=username))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,3 +33,27 @@ async def acanban() -> AsyncIterator[Acanban]:
 def client(app: Acanban) -> QuartClient:
     """Return a Quart test client."""
     return app.test_client()
+
+
+@fixture
+async def assistant(client: QuartClient) -> QuartClient:
+    """Return a test client that is signed in as an academic assistant."""
+    await client.post(
+        '/login', form=dict(username='silasl', password='lsalis'))
+    return client
+
+
+@fixture
+async def student(client: QuartClient) -> QuartClient:
+    """Return a test client that is signed in as a student."""
+    await client.post(
+        '/login', form=dict(username='adaml', password='lmada'))
+    return client
+
+
+@fixture
+async def supervisor(client: QuartClient) -> QuartClient:
+    """Return a test client that is signed in as a supervisor."""
+    await client.post(
+        '/login', form=dict(username='elir', password='rile'))
+    return client

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,0 +1,61 @@
+# Test users
+# Copyright (C) 2020  Ngô Ngọc Đức Huy
+#
+# This file is part of Acanban.
+#
+# Acanban is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Acanban is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Acanban.  If not, see <https://www.gnu.org/licenses/>.
+
+from pytest import mark
+from quart.testing import QuartClient
+
+
+@mark.parametrize(('username', 'code'),
+                  (('nexistepas', 404), ('kiddo', 404),
+                   ('silasl', 200), ('adaml', 200)))
+async def test_view(username: str, code: int,
+                    client: QuartClient) -> None:
+    """Test user view endpoint."""
+    response = await client.get(f'/u/{username}')
+    assert response.status_code == code
+
+
+@mark.parametrize(('username', 'code'),
+                  (('silasl', 200), ('adaml', 403)))
+async def test_edit_view(username: str, code: int,
+                         assistant: QuartClient) -> None:
+    """Test user edit endpoint (GET method)."""
+    response = await assistant.get(f'/u/{username}/edit')
+    assert response.status_code == code
+
+
+async def test_edit_good(assistant: QuartClient) -> None:
+    """Test for user editing name (POST method)."""
+    response = await assistant.post(
+        '/u/silasl/edit', form=dict(name='Silas Salis',
+                                    email='newemail@example.edu'))
+    assert response.status_code == 302
+
+
+async def test_edit_bad_1(assistant: QuartClient) -> None:
+    """Test for user bad request (send empty string)."""
+    response = await assistant.post(
+        '/u/silasl/edit', form=dict(name='', email='newmail@example.edu'))
+    assert response.status_code == 400
+
+
+async def test_edit_bad_2(assistant: QuartClient) -> None:
+    """Test for user sending bad request (lacking field)."""
+    response = await assistant.post(
+        '/u/silasl/edit', form=dict(name='Lacking Email'))
+    assert response.status_code == 400


### PR DESCRIPTION
Resolve #67 

In this project, I implement endpoints `/u/<username>` and `/u/<username>/edit`.

I also edit the title to be a block so that it can be extended in children templates.

This is not done yet: I haven't check if the signed in user is the user that can edit a profile.