### PR TITLE
Rework stylesheet and templates

### DIFF
--- a/src/acanban/auth.py
+++ b/src/acanban/auth.py
@@ -82,7 +82,6 @@ class Authenticator(AuthManager):
         # This never happens through browser, but via manual requests.
         if role not in ROLES: raise ValueError('unknown role')
         async with current_app.db_pool.connection() as connection:
-            user = await self.r.get(username).run(connection)
             user = {'username': username, 'password': crypt(password),
                     'name': name, 'email': email, 'role': role}
             if (await self.r.insert(user).run(connection))['errors']:
@@ -112,7 +111,6 @@ async def register() -> ResponseReturnValue:
     except ValueError as e:
         return await render_template('register.html', error=str(e))
     else:
-        print(info['role'])
         return redirect('/')
 
 

--- a/src/acanban/static/dropdown-icon.svg
+++ b/src/acanban/static/dropdown-icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor">
+<path d="M11.707 12.586L10.293 14 16 19.707 21.707 14l-1.414-1.414L16 16.879z"/>
+<path d="M21 13.293v-1h1v1zm-11 0v-1h1v1z"/>
+<path d="M10 13.293a1 1 0 1 1 2 0 1 1 0 1 1-2 0zm10 0a1 1 0 1 1 2 0 1 1 0 1 1-2 0z"/>
+</svg>

--- a/src/acanban/static/style.css
+++ b/src/acanban/static/style.css
@@ -1,418 +1,177 @@
-input, button {
-    text-align: center;
-    color: #93BBB9;
+/*
+ * Global stylesheet
+ * Copyright (C) 2020  Đào Dương Hoàng Long
+ * Copyright (C) 2020  Nguyễn Gia Phong
+
+ * This file is part of Acanban.
+
+ * Acanban is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * Acanban is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Acanban.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+:root {
+    --color-bg: #ffffff;
+    --color-fg: #171c24;
+    --color-primary-dark: #0088ff;
+    --color-primary-medium: #40a6ff;
+    --color-primary-bright: #80c3ff;
+
+    --color-error-bg: #FFD2D2;
+    --color-error-fg: #D8000C;
+    --color-info-bg: #BDE5F8;
+    --color-info-fg: #00529B;
+    --color-success-bg: #DFF2BF;
+    --color-success-fg: #4F8A10;
+    --color-warning-bg: #FEEFB3;
+    --color-warning-fg: #9F6000;
 }
 
-::-webkit-input-placeholder {
-    text-align: center;
-    color: #93BBB9;
-}
-
-:-moz-placeholder {
-    text-align: center;
-    color: #93BBB9;
-}
-
-::-webkit-scrollbar-track {
-    -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.3);
-    border-radius: 10px;
-    background-color: #F5F5F5;
-}
-
-::-webkit-scrollbar {
-    width: 12px;
-    background-color: #F5F5F5;
-}
-
-::-webkit-scrollbar-thumb {
-    border-radius: 10px;
-    -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,.3);
-    background-color: #DEF2F1;
-}
-
-* {
-    padding: 0;
-    margin: 0;
-    box-sizing: border-box;
-    font-family: 'Public Sans', sans-serif;
-}
-
-
+/* body spacing */
 body {
-    width: 100%;
-    height: 100%;
-    margin: 0 0 0 0;
+    background-color: var(--color-bg);
+    color: var(--color-fg);
+    line-height: 1.6;
+    margin: 0;
+    padding: 0;
 }
-
-/* Styling base.html */
-
-ul {
-    list-style: none;
-}
-
-a {
-    text-decoration: none;
-}
-
 main {
-    height: 82vh;
-}
-
-header {
-    position: sticky;
-    top: 0;
-    width: 100%;
-    z-index: 1000;
-}
-
-header .navbar {
-    max-width: 90vw;
-    padding: 0 4rem;
-    height: 10vh;
-    margin: 0 auto;
-    display: flex;
-}
-
-header .navbar .navbar__logo {
-    flex: 1;
-    display: flex;
-    align-items: center;
-}
-
-header .navbar .navbar__btn {
-    flex: 3;
-    display: flex;
-}
-
-header .navbar .navbar__btn .navbar__links {
-    flex: 2;
-}
-
-header .navbar .navbar__btn .navbar__sign {
-    flex: 1;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-}
-
-header .navbar .navbar__logo .logo {
-    font-family: 'Abhaya Libre';
-    font-size: 3rem;
-    font-weight: 800;
-    cursor: pointer;
-    color: #17242A;
-    letter-spacing: 1px;
-}
-
-header .navbar .navbar__btn .navbar__sign .btn {
-    display: inline-block;
-    padding: .5rem 1.3rem;
-    font-size: 1rem;
-    border: 2px solid #3AAFA9;
-    border-radius: 2rem;
-    line-height: 1;
-    margin: 0 .2rem;
-    transition: 0.3s;
-}
-
-.btn.solid, .btn.transparent:hover {
-    background-color: #3AAFA9;
-    color: #fff;
-}
-
-.btn.transparent, .btn.solid:hover {
-    background-color: transparent;
-    color: #3AAFA9;
-}
-
-.navbar__username {
-    padding: .5rem 1.3rem;
-    display: inline-block;
-    font-size: 1rem;
-    line-height: 1;
-    margin: 0 .2rem;
-}
-
-.footer {
-    width: 100%;
-    height: 8vh;
-    background-color: #17242A;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-}
-
-.footer img {
-    padding: 2px;
-}
-
-/* styling index.html */
-
-.container {
-    position: relative;
-    top: 20px;
-    min-height: 80vh;
-    /* background-image: url('img/image.png') left ; */
-    /*background: linear-gradient(to right, rgba(0,0,0,0.75) 30%, #3AAFA9 80%) left no-repeat,
-    url('img/image.jpg') center;*/
-    background-size: cover ;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    background-color: #b1c7b7;
-}
-
-.container__text-block {
-    width: 60%;
-    text-align: center;
-}
-
-.container .container__text-block h1 {
-    font-family: Abhaya Libre;
-    word-spacing: 1px;
-}
-
-.container .container__text-block p {
-    font-family: Abhaya Libre;
-    padding-top: 20px;
-    word-spacing: 1px;
-}
-@media (max-width: 1080px){
-    header .navbar .navbar__btn .navbar__links{
-        flex: 1;
-    }
-    header .navbar .navbar__btn .navbar__sign{
-        flex: none;
-    }
-}
-@media (max-width: 720px){
-    header .navbar{
-        padding: 0;
-    }
-    header .navbar .navbar__btn .navbar__sign{
-        flex: none;
-    }
-    header .navbar .navbar__btn .navbar__sign .btn {
-        font-size: 1rem;
-        border: none;
-    }
-    .btn.solid, .btn.transparent:hover{
-        background-color: none;
-    }
-    
-    header .navbar .navbar__logo .logo{
-        font-size: 1.5rem;
-    }
-}
-
-@media screen and (min-width: 320px) {
-  .container .container__text-block p {
-    font-size: calc(20px + 6 * ((100vw - 320px) / 680));
-  }
-  .container .container__text-block h1{
-    font-size: calc(25px + 6 * ((100vw - 320px) / 680)); 
-  }
-}
-
-/* styling login.html */
-
-section {
-    position: relative;
-    width: 100%;
-    height: 100vh;
-    display: flex;
-}
-
-section .leftBx:before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-}
-section .leftBx {
-    position: relative;
-    background-color: #17242A;
-    width: 40%;
-    height: 100%;
-}
-
-section .leftBx a {
-    text-decoration: none;
-    font-weight: 500;
-    margin-top: 1rem;
-    margin-right: 1rem;
+    margin: auto;
+    max-width: 36rem;
     padding: 1rem;
-    color: #DEF2F1;
-    padding-left: 1rem;
-    font-family: 'Abhaya Libre';
-    font-size: 4rem;
+}
+h1 { text-align: center }
+p {
+    hyphens: auto;
+    text-align: justify;
+}
+
+/* form */
+form {
+    margin: auto;
+    max-width: 27rem;
+}
+button, input, select, textarea {
+    font-family: inherit;
+    font-size: 100%;
+}
+input[type=text], input[type=password], input[type=email], input[type=submit],
+select {
+    background-color: var(--color-bg);
+    border: 0.1rem solid var(--color-fg);
+    box-sizing: border-box;
+    color: var(--color-fg);
+    margin: 0.5rem 0;
+    padding: 0.5rem;
+    width: 100%;
+}
+select {
+    appearance: none;
+    background: url(/static/dropdown-icon.svg) right center no-repeat;
+}
+input:focus, select:focus {
+    border-color: var(--color-primary-dark);
+    box-shadow: 0 0 0.5rem var(--color-primary-bright);
+}
+input[type=submit] {
+    background-color: var(--color-primary-dark);
+    color: var(--color-bg);
+    cursor: pointer;
+}
+input[type=submit]:hover { background-color: var(--color-primary-medium) }
+
+/* messages */
+.error, .info, .success, .warning {
+    margin: 1rem 0;
+    padding: 0.8rem;
+}
+.error {
+    background-color: var(--color-error-bg);
+    color: var(--color-error-fg);
+}
+.info {
+    background-color: var(--color-info-bg);
+    color: var(--color-info-fg);
+}
+.success {
+    background-color: var(--color-success-bg);
+    color: var(--color-success-fg);
+}
+.warning {
+    background-color: var(--color-warning-bg);
+    color: var(--color-warning-fg);
+}
+
+/* header */
+nav { background-color: var(--color-fg) }
+#nav-icons {
+    float: left;
+    padding: 0.2rem 0;
+}
+#hambutton, #hamburger { display: none }
+#logo, #nav-entries > a {
+    color: var(--color-bg);
+    margin-bottom: auto;
+    margin-top: auto;
+    padding: 1rem;
+    text-decoration: none;
+}
+#logo::selection, #hambutton::selection, #nav-entries > a::selection {
+    background-color: var(--color-fg);
+}
+#logo:hover, #nav-entries > a:hover, #hambutton:hover {
+    color: var(--color-primary-bright);
+}
+#logo {
+    font-size: 1.8rem;
     font-weight: bold;
 }
-
-section .loginBx {
-    background-color: #2B7A77;
+#nav-entries {
     display: flex;
-    justify-content: center;
-    align-items: center;
-    width: 60%;
-    height: 100%;
+    padding: 0 0.5rem;
 }
+.expand { margin-left: auto }
 
-section .loginBx .loginBx__formBx {
-    width: 60%;
-    text-align: center;
-    position: relative;
-}
-
-section .loginBx .loginBx__formBx h2 {
-    color: #DEF2F1;
-    font-weight: 600;
-    font-size: 40px;
-    margin-bottom: 40px;
-    border: 3px solid #DEF2F1 ;
-    border-radius: 10px;
-    display: inline-block;
-    letter-spacing: 1px;
-    padding: 4px;
-    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
-}
-
-section .loginBx .loginBx__formBx .loginBx__inputBx input {
-    width: 100%;
-    padding: 20px 20px;
-    outline: none;
-    font-weight: 400;
-    font-size: 2rem;
-    letter-spacing: 1px;
-    background: transparent;
-    border-radius: 20px;
-    border: none;
-    background-color: white;
-    margin-bottom: 10px;
-    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
-
-}
-
-section .loginBx .loginBx__formBx .loginBx__inputBx input[name="login"] {
-    background-color: #3AAFA9;
-    position: absolute;
-    color: #FFFFFF;
-    width: 150px;
-    right: 0;
-    border-radius: 10px;
-    cursor: pointer;
-}
-
-section .loginBx .loginBx__formBx .loginBx__inputBx .loginBx__backBtn {
-    background-color: #DEF2F1;
-    position: absolute;
-    color: #17242A;
-    width: 150px;
-    left: 0;
-    border-radius: 10px;
-    cursor: pointer;
-    padding: 20px 20px;
-    outline: none;
-    font-weight: 400;
-    font-size: 2rem;
-    letter-spacing: 1px;
-    border: none;
-    margin-bottom: 10px;
-    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
-    text-decoration: none;
-}
-
-section .loginBx .loginBx__formBx .loginBx__inputBx input[name="login"]:hover {
-    background-color: #2da8a2;
-}
-
-section .loginBx .loginBx__formBx .loginBx__inputBx .loginBx__backBtn:hover {
-    background-color: #d3e8e7;
-}
-
-section .loginBx .loginBx__formBx .loginBx__remember {
-    margin-bottom: 10px;
-    color: #DEF2F1;
-    display: flex;
-    font-weight: 400;
-    font-size: 1.5rem;
-    padding-top: 2px;
-}
-
-section .loginBx .loginBx__formBx .loginBx__remember a {
-    margin-bottom: 10px;
-    color: #DEF2F1;
-    font-weight: 400;
-    font-size: 1.5rem;
-    padding-top: 2px;
-    margin-left: auto;
-    text-decoration: none;
-}
-
-@media (max-width: 1080px) {
-    section {
-        flex-direction: column;
-    }
-    section .leftBx {
+/* hamburger menu */
+@media screen and (max-width: 38rem) {
+    nav {
+        position: sticky;
+        top: 0;
         width: 100%;
-        height: 10vh;
     }
-    section .loginBx {
+    #nav-icons {
+        display: flex;
+        float: none;
+        padding: 0;
+    }
+    #logo, #hambutton {
+        color: var(--color-bg);
+        display: inline-block;
+        padding: 0.5rem 1rem;
+    }
+    #logo { font-size: 1rem }
+    #hambutton {
+        margin-left: auto;
+        font-size: 1.4rem;
+    }
+    #nav-entries { display: none }
+    #hamburger:checked ~ #nav-entries {
+        display: block;
+        padding: 0;
+    }
+    #nav-entries > a {
+        border-top: 0.1rem solid #2e3436;
+        padding: 0.5rem 1rem;
+        display: block;
         width: 100%;
-        height: 90vh;
-    }
-
-    section .loginBx .loginBx__formBx{
-        width: 70%;
-    }
-}
-
-@media (max-width: 690px) {
-    section .loginBx .loginBx__formBx{
-        width: 70%;
-    }
-    section .loginBx .loginBx__formBx h2 {
-        font-size: 2rem;
-    }
-    section .loginBx .loginBx__formBx .loginBx__inputBx input[name="login"] {
-        text-align: center;
-        font-size: 2rem;
-    }
-    section .loginBx .loginBx__formBx {
-        width: 70%;
-    }
-}
-
-@media (max-width: 485px){
-    section .leftBx{
-        height: 6vh;
-    }
-    section .leftBx a{
-        font-size: 2rem;
-    }
-    section .loginBx .loginBx__formBx{
-        width: 90%;
-    }
-    section .loginBx .loginBx__formBx .loginBx__remember{
-        font-size: 0.8rem;
-    }
-
-    section .loginBx .loginBx__formBx .loginBx__remember a{
-        font-size:0.8rem;
-    }
-
-    section .loginBx .loginBx__formBx .loginBx__inputBx .loginBx__backBtn{
-        width: 100px;
-        font-size: 1rem;
-    }
-
-    section .loginBx .loginBx__formBx .loginBx__inputBx input[name="login"]{
-        font-size: 1rem;
-        width: 100px;
-    }
-    section .loginBx .loginBx__formBx .loginBx__inputBx input{
-        font-size: 1rem;
     }
 }

--- a/src/acanban/static/style.css
+++ b/src/acanban/static/style.css
@@ -22,9 +22,11 @@
 :root {
     --color-bg: #ffffff;
     --color-fg: #171c24;
+    --color-fg-alt: #2e3436;
     --color-primary-dark: #0088ff;
     --color-primary-medium: #40a6ff;
     --color-primary-bright: #80c3ff;
+    --color-header-search: #eb4034;
 
     --color-error-bg: #FFD2D2;
     --color-error-fg: #D8000C;
@@ -112,7 +114,10 @@ input[type=submit]:hover { background-color: var(--color-primary-medium) }
 }
 
 /* header */
-nav { background-color: var(--color-fg) }
+nav {
+    background-color: var(--color-fg);
+    padding: 0.5rem 1rem;
+}
 #nav-icons {
     float: left;
     padding: 0.2rem 0;
@@ -129,7 +134,7 @@ nav { background-color: var(--color-fg) }
     background-color: var(--color-fg);
 }
 #logo:hover, #nav-entries > a:hover, #hambutton:hover {
-    color: var(--color-primary-bright);
+    color: var(--color-primary-dark);
 }
 #logo {
     font-size: 1.8rem;
@@ -140,10 +145,37 @@ nav { background-color: var(--color-fg) }
     padding: 0 0.5rem;
 }
 .expand { margin-left: auto }
+#search {
+    margin: auto 0.5rem auto;
+    display: flex;
+}
+#search > input {
+    color: var(--color-bg);
+    height: 2.5rem;
+    margin: auto 0 auto 0;
+    padding: 0.5rem;
+}
+#search > input[type=search] {
+    border: 0.1rem solid var(--color-fg-alt);
+    background: var(--color-fg-alt);
+    border-radius: 0.3rem 0 0 0.3rem;
+}
+#search > input[type=submit] {
+    border: 0.1rem solid var(--color-header-search);
+    background: var(--color-header-search);
+    border-radius: 0 0.3rem 0.3rem 0;
+    width: 2.5rem;
+}
+#search > input:focus {
+    border: 0.1rem solid var(--color-header-search);
+    box-shadow: none;
+    outline: none;
+}
 
 /* hamburger menu */
-@media screen and (max-width: 38rem) {
+@media screen and (max-width: 54rem) {
     nav {
+        padding: 0;
         position: sticky;
         top: 0;
         width: 100%;
@@ -169,9 +201,11 @@ nav { background-color: var(--color-fg) }
         padding: 0;
     }
     #nav-entries > a {
-        border-top: 0.1rem solid #2e3436;
+        border-top: 0.1rem solid var(--color-fg-alt);
         padding: 0.5rem 1rem;
         display: block;
         width: 100%;
     }
+    #search { padding: 0 0 1rem 0.5rem }
+    #search > input[type=search] { width: 80% }
 }

--- a/src/acanban/templates/base.html
+++ b/src/acanban/templates/base.html
@@ -37,6 +37,10 @@
       <input type=checkbox id=hamburger>
 
       <div id=nav-entries>
+        <form id=search>
+          <input type=search placeholder=Search>
+          <input type=submit value=Go>
+        </form>
         <a href=/p>Projects</a>
         <a href=/t>Tasks</a>
 

--- a/src/acanban/templates/base.html
+++ b/src/acanban/templates/base.html
@@ -1,67 +1,54 @@
-<!-- Base HTML template
-
-Copyright (C) 2020  Đào Dương Hoàng Long
-
-This file is part of Acanban.
-
-Acanban is free software: you can redistribute it and/or modify
-it under the terms of the GNU Affero General Public License as published
-by the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-Acanban is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Affero General Public License for more details.
-
-You should have received a copy of the GNU Affero General Public License
-along with Acanban.  If not, see <https://www.gnu.org/licenses/>. -->
-
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" type="text/css" href="/static/style.css">
-    <link rel="preconnect" href="https://fonts.gstatic.com">
-    <link href="https://fonts.googleapis.com/css2?family=Public+Sans&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Abhaya+Libre:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-    <link rel="apple-touch-icon" sizes="180x180" href="/static/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/static/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/static/favicon-16x16.png">
-    <link rel="manifest" href="/site.webmanifest">
-    <title>{{title}}</title>
-  </head>
+<!-- Base HTML template
+  Copyright (C) 2020  Đào Dương Hoàng Long
+  Copyright (C) 2020  Nguyễn Gia Phong
+
+  This file is part of Acanban.
+
+  Acanban is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published
+  by the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Acanban is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with Acanban.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
+<html lang=en dir=ltr>
+  <meta charset=utf-8>
+  <meta name=viewport content='width=device-width, initial-scale=1'>
+  <link rel=apple-touch-icon sizes=180x180 href=/static/apple-touch-icon.png>
+  <link rel=icon type=image/png sizes=32x32 href=/static/favicon-32x32.png>
+  <link rel=icon type=image/png sizes=16x16 href=/static/favicon-16x16.png>
+  <link rel=manifest href=/static/site.webmanifest>
+  <link rel=stylesheet type=text/css href=/static/style.css>
+  <title>{% block title %}{% endblock %}</title>
   <body>
-    {% if error %}
-    <p>error: {{ error }}</p>
-    {% endif %}
-    <header>
-      <div class="navbar">
-        <div class="navbar__logo">
-          <a href="/"><h3 class="logo">acanban.</h3></a>
-        </div>
-        <div class="navbar__btn">
-          <div class="navbar__links"></div>
-          <div class="navbar__sign">
-            {% if current_user.is_authenticated %}
-            <a href="" class="navbar__username">Username</a>
-            <a href="/logout" class="btn transparent">Log out</a>
-            {% else %}
-            <a href="/login" class="btn transparent">Log in</a>
-            <a href="/register" class="btn solid">Sign up</a>
-            {% endif %}
-          </div>
-        </div>
+    <nav>
+      <div id=nav-icons>
+        <a id=logo href=/>acanban.</a>
+        <label for=hamburger id=hambutton>&equiv;</label>
       </div>
-    </header>
-    <main>
-      {% block content %}
-      {% endblock %}
-    </main>
-    <div class="footer">
-      <a href="https://github.com/Huy-Ngo/acanban" target="_blank"><img src="https://img.shields.io/github/stars/Huy-Ngo/acanban?style=social"></a>
-      <a href="#"><img src="https://img.shields.io/github/license/Huy-Ngo/acanban?style=social"></a>
-    </div>
+      <input type=checkbox id=hamburger>
+
+      <div id=nav-entries>
+        <a href=/p>Projects</a>
+        <a href=/t>Tasks</a>
+
+        {% if current_user.is_authenticated %}
+        <a href='/u/{{ current_user.key }}' class=expand>My Profile</a>
+        <a href=/logout>Logout</a>
+        {% else %}
+        <a href=/login class=expand>Login</a>
+        <a href=/register>Register</a>
+        {% endif %}
+      </div>
+    </nav>
+    <main>{% block content %}{% endblock %}</main>
   </body>
 </html>

--- a/src/acanban/templates/index.html
+++ b/src/acanban/templates/index.html
@@ -1,32 +1,47 @@
 <!-- Index page
-Copyright (C) 2020  Đào Dương Hoàng Long
+  Copyright (C) 2020  Đào Dương Hoàng Long
+  Copyright (C) 2020  Nguyễn Gia Phong
 
-This file is part of Acanban.
+  This file is part of Acanban.
 
-Acanban is free software: you can redistribute it and/or modify
-it under the terms of the GNU Affero General Public License as published
-by the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+  Acanban is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published
+  by the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
 
-Acanban is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Affero General Public License for more details.
+  Acanban is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Affero General Public License for more details.
 
-You should have received a copy of the GNU Affero General Public License
-along with Acanban.  If not, see <https://www.gnu.org/licenses/>. -->
+  You should have received a copy of the GNU Affero General Public License
+  along with Acanban.  If not, see <https://www.gnu.org/licenses/>.
+-->
 
 {% extends "base.html" %}
-
+{% block title %}Acanban{% endblock %}
 {% block content %}
-<div class="container">
-  <div class="container__text-block">
-    <h1>acanban. is an academic Kanban board.</h1>
-    <p>\ah•kahn•bahn\</p>
-    <p>
-    Aim to provide a collaboration platform for students and
-    mentors, with first-class support for academic evaluation.
-    </p>
-  </div>
-</div>
+<h1>Header 1</h1>
+<h2>Header 2</h2>
+<h3>Header 3</h3>
+<div class=error>Some ERROR text.</div>
+<div class=info>Some INFO text.</div>
+<div class=success>Some SUCCESS text.</div>
+<div class=warning>Some WARNING text.</div>
+<p>
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+  tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+  quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+  consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+  cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+  proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+</p>
+<form>
+  <input type=text placeholder=text required>
+  <input type=email placeholder=email required>
+  <input type=password placeholder=password required>
+  <input type=checkbox name=checkbox>
+  <label for=remember>Checkbox</label>
+  <input type=submit value=Submit>
+</form>
 {% endblock %}

--- a/src/acanban/templates/login.html
+++ b/src/acanban/templates/login.html
@@ -1,60 +1,35 @@
 <!-- Login page
-Copyright (C) 2020  Đào Dương Hoàng Long
+  Copyright (C) 2020  Đào Dương Hoàng Long
+  Copyright (C) 2020  Nguyễn Gia Phong
 
-This file is part of Acanban.
+  This file is part of Acanban.
 
-Acanban is free software: you can redistribute it and/or modify
-it under the terms of the GNU Affero General Public License as published
-by the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+  Acanban is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published
+  by the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
 
-Acanban is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Affero General Public License for more details.
+  Acanban is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Affero General Public License for more details.
 
-You should have received a copy of the GNU Affero General Public License
-along with Acanban.  If not, see <https://www.gnu.org/licenses/>. -->
+  You should have received a copy of the GNU Affero General Public License
+  along with Acanban.  If not, see <https://www.gnu.org/licenses/>.
+-->
 
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-wid	th, initial-scale=1.0">
-    <link rel="stylesheet" type="text/css" href="/static/style.css">
-    <title>{{title}}</title>
-  </head>
-  <body>
-    {% if error %}
-    <p>error: {{ error }}</p>
-    {% endif %}
-    <section>
-      <div class="leftBx">
-        <a href="/" class="navbar__logo">acanban.</a>
-      </div>
-      <div class="loginBx">
-        <div class="loginBx__formBx">
-          <h2>Login</h2>
-          <form action=login method=POST>
-            <div class="loginBx__inputBx">
-              <input type="text" name="username" id="username" placeholder="Username">
-            </div>
-            <div class="loginBx__inputBx">
-              <input type="password" name="password" id="password" placeholder="Password">
-            </div>
-            <div class="loginBx__remember">
-              <label><input type="checkbox" name="remember" id="remember">Remember me</label>
-              <a href="#">Forgot your password?</a>
-            </div>
-            <div class="loginBx__inputBx">
-              <input type="submit" name="login" value="Login">
-            </div>
-            <div class="loginBx__inputBx">
-              <a class="loginBx__backBtn" href="/">Back</a>
-            </div>
-          </form>
-        </div>
-      </div>
-    </section>
-  </body>
-</html>
+{% extends "base.html" %}
+{% block title %}Login{% endblock %}
+{% block content %}
+<h1>Log in to acanban</h1>
+<form action=login method=POST>
+  {% if error %}
+  <div class=error>{{ error }}</div>
+  {% endif %}
+  <input type=text name=username id=username placeholder=username required>
+  <input type=password name=password id=password placeholder=password required>
+  <input type=checkbox name=remember id=remember>
+  <label for=remember>Remember me</label>
+  <input type=submit name=submit value=Login>
+</form>
+{% endblock %}

--- a/src/acanban/templates/register.html
+++ b/src/acanban/templates/register.html
@@ -1,23 +1,39 @@
-<!DOCTYPE html>
-<html>
-<meta charset=utf-8>
-<title>Registration</title>
-<body>
-{% if error %}
-<p>error: {{ error }}</p>
-{% endif %}
+<!-- Registration page
+  Copyright (C) 2020  Nguyễn Gia Phong
+
+  This file is part of Acanban.
+
+  Acanban is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published
+  by the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Acanban is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with Acanban.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
+{% extends "base.html" %}
+{% block title %}Registration{% endblock %}
+{% block content %}
+<h1>Register for acanban</h1>
 <form action=register method=POST>
-  <input type=text name=username id=username placeholder=username><br>
-  <input type=password name=password id=password placeholder=password><br>
-  <input type=text name=name id=name placeholder=name><br>
-  <input type=email name=email id=email placeholder=email><br>
+  {% if error %}
+  <div class=error>{{ error }}</div>
+  {% endif %}
+  <input type=text name=username id=username placeholder=username required>
+  <input type=password name=password id=password placeholder=password required>
+  <input type=text name=name id=name placeholder=name required>
+  <input type=email name=email id=email placeholder=email required>
   <select name=role id=role>
     <option value=student>student</option>
     <option value=supervisor>supervisor</option>
     <option value=staff>staff</option>
-    <option value=admin>admin</option>
-  </select><br>
-  <input type=submit name=submit value=register>
+  </select>
+  <input type=submit name=submit value=Register>
 </form>
-</body>
-</html>
+{% endblock %}


### PR DESCRIPTION
Currently there are 2 cases are handled, width less than and greater than 54rem (c572379560529a12136c42b5a018b7f3a13c89e7) / 38rem (b01b5019d86676c8ab4557e166c3d0747c2811aa).

~Details like color and border can be added later,~ this is solely to provide an unified style across pages, just enough to resolve GH-63.

I'm sorry that I remove a lot of things—there are too many placeholders that I find too time-consuming to maintain backward-compatibility.