### PR TITLE
Build PDF via CI

### DIFF
--- a/.builds/print.yml
+++ b/.builds/print.yml
@@ -1,0 +1,25 @@
+image: debian/sid
+arch: amd64
+packages:
+  - ghostscript
+  - latexmk
+  - lmodern
+  - graphviz
+  - plantuml
+  - python3-pip
+  - python3-sphinx
+  - texlive
+  - texlive-font-utils
+  - texlive-lang-other
+  - texlive-latex-extra
+artifacts:
+  - acanban/docs/build/latex/acanban.pdf
+sources:
+  - https://github.com/Huy-Ngo/acanban
+tasks:
+  - prepare: |
+      python3 -m pip install -U pip
+      python3 -m pip install sphinxcontrib.plantuml ./acanban
+  - print: make -C acanban/docs latexpdf
+environment:
+  PIP_PROGRESS_BAR: 'off'


### PR DESCRIPTION
On [a *print* build](https://builds.sr.ht/~huyngo/job/384391), one may find in the artifacts section [a download link to the built PDF](https://patchouli.sr.ht/builds.sr.ht/artifacts/~huyngo/384391/c9905d43933fc0fa/acanban.pdf).