### PR TITLE
Fix the markdown parsing order

### DIFF
--- a/src/acanban/__init__.py
+++ b/src/acanban/__init__.py
@@ -91,7 +91,7 @@ app.add_template_filter(naturalsize)
 
 @app.template_filter('markdown')
 def as_markdown(text: str) -> str:
-    html = clean(markdown(linkify(text)), markdown_tags, markdown_attrs)
+    html = clean(linkify(markdown(text)), markdown_tags, markdown_attrs)
     return html
 
 


### PR DESCRIPTION
Someone told me I should keep my commit and PRs small so this is like the second or third time I applied it.

Switch markdown() and linkify() so that the image URLs don't turn into HTML tags.

Fixes #241 