### PR TITLE
Fix PyPI upload automation

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -2,6 +2,7 @@ image: debian/buster
 arch: amd64
 packages:
   - python3-pip
+  - python3-venv
   - rethinkdb
   - wget
 repositories:
@@ -21,11 +22,12 @@ tasks:
       python3 -m pip install tox
       python3 -m tox -c acanban
   - cd: |
-      cd acanban
-      if [[ $(git tag --points-at HEAD) ]]
+      if [[ $(git -C acanban tag --points-at HEAD) ]]
       then
-        python3 -m pip install flit
-        python3 -m flit publish
+        python3 -m pip install --upgrade pip
+        python3 -m pip install build twine
+        python3 -m build --sdist --wheel acanban
+        python3 -m twine upload acanban/dist/*
       fi
 environment:
   PIP_PROGRESS_BAR: 'off'

--- a/src/acanban/__init__.py
+++ b/src/acanban/__init__.py
@@ -46,7 +46,7 @@ from .user import blueprint as user
 
 __all__ = ['app']
 __doc__ = 'Academic Kanban'
-__version__ = '0.1.2'
+__version__ = '0.1.2.post0'
 
 # Nope, the negative operator is not a typo, see also tzset(3posix).
 TZ = tz(timedelta(seconds=-timezone))


### PR DESCRIPTION
I forgot that `flit publish` does not install dependencies, and thus fails to build.  `build` is a PEP 517 frontend and thus is more portable than calling for `flit` explicitly, although I doubt if we ever change the build backend.